### PR TITLE
Standardize README and remove stale release version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# SDMX Information Model
+
+This submodule contains the SDMX Information Model, Framework, Logical
+Interfaces, and Technical Notes documentation components used within the
+[`sdmx-docs`](https://github.com/sdmx-twg/sdmx-docs) unified documentation
+site.
+
+## Repository Structure
+
+-   `docs/` — content pages, organised into four sub-folders:
+    -   `docs/framework/`
+    -   `docs/information_model/`
+    -   `docs/logical_interfaces/`
+    -   `docs/technical_notes/`
+
+| File                            | Section served                 |
+| ------------------------------- | ------------------------------ |
+| `mkdocs_framework.yml`          | Section 1 — Framework          |
+| `mkdocs_information_model.yml`  | Section 2 — Information Model  |
+| `mkdocs_logical_interfaces.yml` | Section 5 — Logical Interfaces |
+| `mkdocs_technical_notes.yml`    | Section 6 — Technical Notes    |
+
+## Version Branches
+
+Each release of this component is maintained on a dedicated branch following the
+pattern `X.Y.x` (e.g., `3.1.x`). The branch tracked by the
+[`sdmx-docs`](https://github.com/sdmx-twg/sdmx-docs) parent repository is
+declared in `.gitmodules` at the root of that repo. Switching the tracked branch
+in the parent repository is how a new version of this component is published on
+the documentation site.
+
+## Formatting Conventions
+
+For Markdown and MkDocs formatting conventions that apply to content in `docs/`,
+see the [`sdmx-docs` README](https://github.com/sdmx-twg/sdmx-docs#readme).


### PR DESCRIPTION
Full rewrite: remove legacy badges and IM-specific authoring guidance; add Repository Structure, Version Branches, and Formatting Conventions sections; resolve placeholder sdmx-docs parent-repo link.