### PR TITLE
fix: correct links to the Registry Specification in documentation

### DIFF
--- a/docs/framework/2_framework-processes-and-business-scope.md
+++ b/docs/framework/2_framework-processes-and-business-scope.md
@@ -468,7 +468,7 @@ registry -- instead, it specifies the standard interfaces which may be
 supported by a registry. Thus, users may implement an SDMX-conformant
 registry in any fashion they choose, provided the interfaces are
 supported as specified in the
-[Registry Specification Section](../../registry_specification/registry_specification/1_Introduction.md).
+[Registry Specification Section](../../registry_specification/1_Introduction.md).
 These interfaces are expressed as XML documents, but also REST API
 request/response messages
 

--- a/docs/information_model/12_Data_Provisioning.md
+++ b/docs/information_model/12_Data_Provisioning.md
@@ -23,7 +23,7 @@ above, the classes in the grey shaded area are specific to a
 registry-based scenario where data sources (either physical data and
 metadata sets or databases and metadata repositories) are registered.
 More details on how these classes are used in a registry scenario can be
-found in the SDMX Registry Interface document. (Section [Registry Specification](../../registry_specification/registry_specification/1_Introduction.md)).
+found in the SDMX Registry Interface document. (Section [Registry Specification](../../registry_specification/1_Introduction.md)).
 
 A `ProvisionAgreement` / `MetadataProvisionAgreement` links the artefact
 that defines how data / metadata are structured and classified


### PR DESCRIPTION
The links to the registry specifications sections were not working properly, as the repository was split into two. This PR fixes the links.